### PR TITLE
changes for Python 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ def get_mpi_flags():
     # Split the output from the mpicxx command
     args = check_output(['mpicxx', '-show']).split()
 
+    # decode strings to utf-8 (for Python 3 to avoid bytes literals)
+    args = [x.decode('utf-8') for x in args]
+
     # Determine whether the output is an include/link/lib command
     inc_dirs, lib_dirs, libs = [], [], []
     for flag in args:
@@ -63,7 +66,6 @@ inc_dirs.extend([numpy.get_include(), mpi4py.get_include()])
 exts = []
 for mod in ['TACS', 'elements', 'constitutive', 'functions']:
     exts.append(Ext('tacs.%s'%(mod), sources=['tacs/%s.pyx'%(mod)],
-                    language='c++',
                     include_dirs=inc_dirs, libraries=libs, 
                     library_dirs=lib_dirs, runtime_library_dirs=runtime_lib_dirs))
 for e in exts:
@@ -75,5 +77,4 @@ setup(name='tacs',
       description='Parallel finite-element analysis package',
       author='Graeme J. Kennedy',
       author_email='graeme.kennedy@ae.gatech.edu',
-      ext_modules=cythonize(exts, language='c++', 
-        include_path=inc_dirs))
+      ext_modules=cythonize(exts, include_path=inc_dirs))

--- a/tacs/TACS.pxd
+++ b/tacs/TACS.pxd
@@ -10,6 +10,8 @@
 #
 #  http://www.apache.org/licenses/LICENSE-2.0
 
+# distutils: language=c++
+
 # For MPI capabilities
 from mpi4py.libmpi cimport *
 cimport mpi4py.MPI as MPI

--- a/tacs/TACS.pyx
+++ b/tacs/TACS.pyx
@@ -10,6 +10,8 @@
 #
 #  http://www.apache.org/licenses/LICENSE-2.0
 
+# distutils: language=c++
+
 from __future__ import print_function, division
 
 # For the use of MPI

--- a/tacs/constitutive.pxd
+++ b/tacs/constitutive.pxd
@@ -10,6 +10,8 @@
 #  
 #  http://www.apache.org/licenses/LICENSE-2.0 
 
+# distutils: language=c++
+
 # For MPI capabilities
 from mpi4py.libmpi cimport *
 cimport mpi4py.MPI as MPI

--- a/tacs/constitutive.pyx
+++ b/tacs/constitutive.pyx
@@ -10,6 +10,8 @@
 #  
 #  http://www.apache.org/licenses/LICENSE-2.0 
 
+# distutils: language=c++
+
 # For the use of MPI
 from mpi4py.libmpi cimport *
 cimport mpi4py.MPI as MPI

--- a/tacs/elements.pxd
+++ b/tacs/elements.pxd
@@ -10,6 +10,8 @@
 #
 #  http://www.apache.org/licenses/LICENSE-2.0
 
+# distutils: language=c++
+
 # For MPI capabilities
 from mpi4py.libmpi cimport *
 cimport mpi4py.MPI as MPI

--- a/tacs/elements.pyx
+++ b/tacs/elements.pyx
@@ -10,6 +10,8 @@
 #
 #  http://www.apache.org/licenses/LICENSE-2.0
 
+# distutils: language=c++
+
 # For the use of MPI
 from mpi4py.libmpi cimport *
 cimport mpi4py.MPI as MPI

--- a/tacs/functions.pxd
+++ b/tacs/functions.pxd
@@ -10,6 +10,8 @@
 #  
 #  http://www.apache.org/licenses/LICENSE-2.0 
 
+# distutils: language=c++
+
 # For MPI capabilities
 from mpi4py.libmpi cimport *
 cimport mpi4py.MPI as MPI

--- a/tacs/functions.pyx
+++ b/tacs/functions.pyx
@@ -10,6 +10,8 @@
 #  
 #  http://www.apache.org/licenses/LICENSE-2.0 
 
+# distutils: language=c++
+
 # For the use of MPI
 from mpi4py.libmpi cimport *
 cimport mpi4py.MPI as MPI


### PR DESCRIPTION
Added decoding of compiler flags to UTF-8. Building using Python 3 (on Mac) didn't include the include directories (although they were found in setup.py) because the string comparison was failing for bytes literals. Also moved the c++ language option to the Cython files and removed it from setup.py, as the language option for cythonize is deprecated.