### PR TITLE
Adding a lot of interface for beam elements

### DIFF
--- a/docs/source/core/elements.rst
+++ b/docs/source/core/elements.rst
@@ -32,7 +32,7 @@ Some :class:`~TACS.Element` classes require transform classes in their setup pro
 The following transform classes are available in TACS:
 
 .. automodule:: tacs.elements
-  :members: ShellNaturalTransform, ShellRefAxisTransform,
+  :members: ShellNaturalTransform, ShellRefAxisTransform, BeamRefAxisTransform,
     SpringIdentityTransform, SpringRefAxisTransform, SpringRefFrameTransform
   :show-inheritance:
 

--- a/examples/beam/analysis.py
+++ b/examples/beam/analysis.py
@@ -1,0 +1,99 @@
+"""
+Structural model of a slot made from 3D tetrahedral elements.
+The slot is constrained at its bolt holes and a set of point
+forces are applied at the top of the slot.
+"""
+# ==============================================================================
+# Standard Python modules
+# ==============================================================================
+from __future__ import print_function
+import os
+
+# ==============================================================================
+# External Python modules
+# ==============================================================================
+from pprint import pprint
+from mpi4py import MPI
+import numpy as np
+
+# ==============================================================================
+# Extension modules
+# ==============================================================================
+from tacs import constitutive, elements, functions, pyTACS
+
+comm = MPI.COMM_WORLD
+
+# Instantiate FEAAssembler
+structOptions = {}
+
+bdfFile = os.path.join(os.path.dirname(__file__), 'beam_model.bdf')
+# Load BDF file
+FEAAssembler = pyTACS(bdfFile, comm, options=structOptions)
+
+# Material properties
+rho = 2700.0        # density kg/m^3
+E = 70.0e9          # Young's modulus (Pa)
+nu = 0.3           # Poisson's ratio
+ys = 270.0e6        # yield stress
+
+# Shell thickness
+A = 0.1            # m
+Iz = 0.2        # m
+Iy = 0.3         # m
+J = 0.4
+
+# Callback function used to setup TACS element objects and DVs
+def elemCallBack(dvNum, compID, compDescript, elemDescripts, globalDVs, **kwargs):
+    # Setup (isotropic) property and constitutive objects
+    prop = constitutive.MaterialProperties(rho=rho, E=E, nu=nu, ys=ys)
+    # Tube beam constitutive properties (defaults to D=1.0, tw=0.1)
+    con = constitutive.IsoTubeBeamConstitutive(prop)#constitutive.BasicBeamConstitutive1(prop, A=A, Iy=Iy, Iz=Iz, J=J)
+
+    refAxis = np.array([0.0, 1.0, 0.0])
+
+    # For each element type in this component,
+    # pass back the appropriate tacs element object
+    transform = elements.BeamRefAxisTransform(refAxis)
+    elem = elements.LinearBeam(transform, con)
+    return elem
+
+# Set up elements and TACS assembler
+FEAAssembler.initialize(elemCallBack)
+
+# ==============================================================================
+# Setup static problem
+# ==============================================================================
+# Static problem
+evalFuncs = ['mass', 'ks_vmfailure']
+
+# Create a static problem with a simple z shear load at tip node
+problem = FEAAssembler.createStaticProblem('z-shear')
+problem.addLoadToNodes(6, [0.0, 0.0, 1.0e10, 0.0, 0.0, 0.0], nastranOrdering=True)
+# Add some eval funcs
+problem.addFunction('mass', functions.StructuralMass)
+problem.addFunction('ks_vmfailure', functions.KSFailure, safetyFactor=1.5,
+                    ksWeight=100.0)
+
+# Solve state
+problem.solve()
+
+# Solve fails, because some of the Jacobian rows/cols are all zeros
+K = problem.K.getDenseMatrix()
+if np.linalg.det(K) == 0:
+    raise AssertionError("Stiffness matrix is singular!!!")
+
+# Evaluate functions
+funcs = {}
+problem.evalFunctions(funcs, evalFuncs=evalFuncs)
+
+if comm.rank == 0:
+    pprint(funcs)
+
+# Evaluate function sensitivities
+funcsSens = {}
+problem.evalFunctionsSens(funcsSens, evalFuncs=evalFuncs)
+if comm.rank == 0:
+    pprint(funcsSens)
+
+# Write solution out
+problem.writeSolution(outputDir=os.path.dirname(__file__))

--- a/examples/beam/analysis.py
+++ b/examples/beam/analysis.py
@@ -1,7 +1,6 @@
 """
-Structural model of a slot made from 3D tetrahedral elements.
-The slot is constrained at its bolt holes and a set of point
-forces are applied at the top of the slot.
+6 noded beam model 1 meter long in x direction.
+We apply a tip load in the z direction and clamp it at the root.
 """
 # ==============================================================================
 # Standard Python modules

--- a/examples/beam/beam_model.bdf
+++ b/examples/beam/beam_model.bdf
@@ -1,0 +1,65 @@
+INIT MASTER(S)
+NASTRAN SYSTEM(442)=-1,SYSTEM(319)=1
+ID FEMAP,FEMAP
+SOL SESTATIC
+CEND
+  TITLE = Beam Test
+  ECHO = NONE
+  DISPLACEMENT(PLOT) = ALL
+  SPCFORCE(PLOT) = ALL
+  OLOAD(PLOT) = ALL
+  FORCE(PLOT,CORNER) = ALL
+  STRESS(PLOT,CORNER) = ALL
+SUBCASE 1
+  SUBTITLE = z-shear
+  SPC = 1
+  LOAD = 1
+SUBCASE 2
+  SUBTITLE = y-shear
+  SPC = 1
+  LOAD = 2
+BEGIN BULK
+$ ***************************************************************************
+$   Written by : Femap
+$   Version    : 2021.1.0
+$   Translator : Simcenter Nastran
+$   From Model : 
+$   Date       : Wed Apr 20 10:23:42 2022
+$   Output To  : C:\Users\trbrooks\AppData\Local\Temp\3\
+$ ***************************************************************************
+$
+PARAM,PRGPST,YES
+PARAM,POST,-1
+PARAM,OGEOM,NO
+PARAM,AUTOSPC,YES
+PARAM,K6ROT,100.
+PARAM,GRDPNT,0
+CORD2C         1       0      0.      0.      0.      0.      0.      1.+FEMAPC1
++FEMAPC1      1.      0.      1.        
+CORD2S         2       0      0.      0.      0.      0.      0.      1.+FEMAPC2
++FEMAPC2      1.      0.      1.        
+$ Femap Load Set 1 : Shear
+FORCE          1       6       0      1.      0.      0.   1.+10
+$ Femap Load Set 2 : y-shear
+FORCE          2       6       0      1.      0.   1.+10      0.
+$ Femap Constraint Set 1 : Case 1
+SPC1           1  123456       1
+$ Femap Property 1 : Beam
+PBAR           1       1      .1      .2      .3      .4      0.        +       
++             0.      0.      0.      0.      0.      0.      0.      0.+       
++                             0.
+$ Femap Material 1 : Aluminum
+MAT1           1   7.+10              .3   2700.      0.      0.        +       
++          2.7+8                
+GRID           1       0      0.      0.      0.       0
+GRID           2       0      .2      0.      0.       0
+GRID           3       0      .4      0.      0.       0
+GRID           4       0      .6      0.      0.       0
+GRID           5       0      .8      0.      0.       0
+GRID           6       0      1.      0.      0.       0
+CBAR           1       1       1       2      0.      1.      0.
+CBAR           2       1       2       3      0.      1.      0.
+CBAR           3       1       3       4      0.      1.      0.
+CBAR           4       1       4       5      0.      1.      0.
+CBAR           5       1       5       6      0.      1.      0.
+ENDDATA e0194509

--- a/src/constitutive/TACSBasicBeamConstitutive.cpp
+++ b/src/constitutive/TACSBasicBeamConstitutive.cpp
@@ -89,6 +89,40 @@ TACSBasicBeamConstitutive::TACSBasicBeamConstitutive( TacsScalar EA,
   Set the diagonal components of the stiffness matrix and the mass
   moments of the cross-section.
 */
+TACSBasicBeamConstitutive::TACSBasicBeamConstitutive( TacsScalar rhoA,
+                                                      TacsScalar rhoIy,
+                                                      TacsScalar rhoIz,
+                                                      TacsScalar rhoIyz,
+                                                      TacsScalar EA,
+                                                      TacsScalar GJ,
+                                                      TacsScalar EIy,
+                                                      TacsScalar EIz,
+                                                      TacsScalar kGAy,
+                                                      TacsScalar kGAz ){
+  props = NULL;
+
+  // Set the entries of the stiffness matrix
+  memset(C, 0, NUM_TANGENT_STIFFNESS_ENTRIES*sizeof(TacsScalar));
+  C[0] = EA;
+  C[6] = GJ;
+  C[11] = EIy;
+  C[15] = EIz;
+  C[18] = kGAy;
+  C[20] = kGAz;
+
+  // Set the entries of the density matrix
+  rho[0] = rhoA;
+  rho[1] = 0.0;
+  rho[2] = 0.0;
+  rho[3] = rhoIy;
+  rho[4] = rhoIz;
+  rho[5] = rhoIyz;
+}
+
+/*
+  Set the diagonal components of the stiffness matrix and the mass
+  moments of the cross-section.
+*/
 TACSBasicBeamConstitutive::TACSBasicBeamConstitutive( TACSMaterialProperties *properties,
                                                       TacsScalar A,
                                                       TacsScalar J,

--- a/src/constitutive/TACSBasicBeamConstitutive.cpp
+++ b/src/constitutive/TACSBasicBeamConstitutive.cpp
@@ -76,11 +76,11 @@ TACSBasicBeamConstitutive::TACSBasicBeamConstitutive( TacsScalar EA,
 
   // Set the entries of the density matrix
   rho[0] = m00;
-  rho[0] = xm2*m00;
+  rho[1] = xm2*m00;
   rho[2] = xm3*m00;
   rho[3] = m11;
   rho[4] = m22;
-  rho[5] = m00*xm2*xm3;
+  rho[5] = m33; // m00*xm2*xm3;
 }
 
 /*
@@ -88,9 +88,9 @@ TACSBasicBeamConstitutive::TACSBasicBeamConstitutive( TacsScalar EA,
   moments of the cross-section.
 */
 TACSBasicBeamConstitutive::TACSBasicBeamConstitutive( TacsScalar rhoA,
+                                                      TacsScalar rhoJ,
                                                       TacsScalar rhoIy,
                                                       TacsScalar rhoIz,
-                                                      TacsScalar rhoIyz,
                                                       TacsScalar EA,
                                                       TacsScalar GJ,
                                                       TacsScalar EIy,
@@ -110,7 +110,7 @@ TACSBasicBeamConstitutive::TACSBasicBeamConstitutive( TacsScalar rhoA,
   rho[0] = rhoA;
   rho[1] = 0.0;
   rho[2] = 0.0;
-  rho[3] = rhoIy;
-  rho[4] = rhoIz;
-  rho[5] = rhoIyz;
+  rho[3] = rhoJ;
+  rho[4] = rhoIy;
+  rho[5] = rhoIz;
 }

--- a/src/constitutive/TACSBasicBeamConstitutive.h
+++ b/src/constitutive/TACSBasicBeamConstitutive.h
@@ -33,8 +33,8 @@ class TACSBasicBeamConstitutive : public TACSBeamConstitutive {
                              TacsScalar xc2, TacsScalar xc3,
                              TacsScalar xk2, TacsScalar xk3,
                              TacsScalar muS );
-  TACSBasicBeamConstitutive( TacsScalar rhoA, TacsScalar rhoIy,
-                             TacsScalar rhoIz, TacsScalar rhoIyz,
+  TACSBasicBeamConstitutive( TacsScalar rhoA, TacsScalar rhoJ,
+                             TacsScalar rhoIy, TacsScalar rhoIz,
                              TacsScalar EA, TacsScalar GJ,
                              TacsScalar EIy, TacsScalar EIz,
                              TacsScalar kGAy, TacsScalar kGAz );

--- a/src/constitutive/TACSBasicBeamConstitutive.h
+++ b/src/constitutive/TACSBasicBeamConstitutive.h
@@ -34,6 +34,11 @@ class TACSBasicBeamConstitutive : public TACSBeamConstitutive {
                              TacsScalar xc2, TacsScalar xc3,
                              TacsScalar xk2, TacsScalar xk3,
                              TacsScalar muS );
+  TACSBasicBeamConstitutive( TacsScalar rhoA, TacsScalar rhoIy,
+                             TacsScalar rhoIz, TacsScalar rhoIyz,
+                             TacsScalar EA, TacsScalar GJ,
+                             TacsScalar EIy, TacsScalar EIz,
+                             TacsScalar kGAy, TacsScalar kGAz );
   TACSBasicBeamConstitutive( TACSMaterialProperties *properties,
                              TacsScalar A, TacsScalar J, TacsScalar Iy, TacsScalar Iz,
                              TacsScalar kcorr=5.0/6.0 );

--- a/src/constitutive/TACSBasicBeamConstitutive.h
+++ b/src/constitutive/TACSBasicBeamConstitutive.h
@@ -20,6 +20,7 @@
 */
 
 #include "TACSBeamConstitutive.h"
+#include "TACSMaterialProperties.h"
 
 class TACSBasicBeamConstitutive : public TACSBeamConstitutive {
  public:
@@ -33,11 +34,11 @@ class TACSBasicBeamConstitutive : public TACSBeamConstitutive {
                              TacsScalar xc2, TacsScalar xc3,
                              TacsScalar xk2, TacsScalar xk3,
                              TacsScalar muS );
-  TACSBasicBeamConstitutive( TacsScalar rhoA, TacsScalar rhoJ,
-                             TacsScalar rhoIy, TacsScalar rhoIz,
-                             TacsScalar EA, TacsScalar GJ,
-                             TacsScalar EIy, TacsScalar EIz,
-                             TacsScalar kGAy, TacsScalar kGAz );
+  TACSBasicBeamConstitutive( TACSMaterialProperties *properties,
+                             TacsScalar A, TacsScalar J, TacsScalar Iy, TacsScalar Iz,
+                             TacsScalar kcorr=5.0/6.0 );
+
+  ~TACSBasicBeamConstitutive();
 
   /**
     Get the cross-sectional mass per unit area and the second moments
@@ -111,12 +112,21 @@ class TACSBasicBeamConstitutive : public TACSBeamConstitutive {
     return 0.0;
   }
 
+  // The name of the constitutive object
+  const char *getObjectName();
+
  private:
   // The constitutive matrix
   TacsScalar C[36];
 
   // The moments of the density
   TacsScalar rho[6];
+
+  // Material properties class
+  TACSMaterialProperties *props;
+
+  // The object name
+  static const char *constName;
 };
 
 #endif // TACS_BASIC_BEAM_CONSTITUTIVE_H

--- a/src/constitutive/TACSIsoTubeBeamConstitutive.cpp
+++ b/src/constitutive/TACSIsoTubeBeamConstitutive.cpp
@@ -387,3 +387,12 @@ TacsScalar TACSIsoTubeBeamConstitutive::evalDesignFieldValue( int elemIndex,
   }
   return 0.0;
 }
+
+const char* TACSIsoTubeBeamConstitutive::constName = "TACSIsoTubeBeamConstitutive";
+
+/*
+  Return the constitutive name
+*/
+const char* TACSIsoTubeBeamConstitutive::getObjectName(){
+  return constName;
+}

--- a/src/constitutive/TACSIsoTubeBeamConstitutive.h
+++ b/src/constitutive/TACSIsoTubeBeamConstitutive.h
@@ -95,6 +95,9 @@ class TACSIsoTubeBeamConstitutive : public TACSBeamConstitutive {
                          const TacsScalar strain[],
                          int dvLen, TacsScalar dfdx[] );
 
+  // The name of the constitutive object
+  const char *getObjectName();
+
   // Retrieve the design variable for plotting purposes
   TacsScalar evalDesignFieldValue( int elemIndex,
                                    const double pt[],
@@ -106,6 +109,8 @@ class TACSIsoTubeBeamConstitutive : public TACSBeamConstitutive {
   int innerDV, wallDV;
   TacsScalar innerLb, innerUb;
   TacsScalar wallLb, wallUb;
+  // The object name
+  static const char *constName;
 };
 
 #endif // TACS_ISO_TUBE_BEAM_CONSTITUTIVE_H

--- a/src/elements/shell/TACSBeamElement.h
+++ b/src/elements/shell/TACSBeamElement.h
@@ -233,6 +233,10 @@ class TACSBeamElement : public TACSElement {
     con->incref();
   }
 
+  const char* getObjectName(){
+    return "TACSBeamElement";
+  }
+
   int getVarsPerNode(){
     return vars_per_node;
   }
@@ -242,6 +246,10 @@ class TACSBeamElement : public TACSElement {
 
   ElementLayout getLayoutType(){
     return basis::getLayoutType();
+  }
+
+  ElementType getElementType(){
+    return TACS_BEAM_OR_SHELL_ELEMENT;
   }
 
   int getNumQuadraturePoints(){

--- a/src/elements/shell/TACSShellElementDefs.h
+++ b/src/elements/shell/TACSShellElementDefs.h
@@ -102,6 +102,26 @@ typedef TACSShellElement<TACSQuadCubicQuadrature, TACSShellQuadBasis<4>,
 typedef TACSShellElement<TACSTriLinearQuadrature, TACSShellTriLinearBasis,
                          TACSQuaternionRotation, TACSShellInplaneLinearModel> TACSTri3ShellQuaternion;
 
+// TODO: Linear in name is ambiguous (quadrature or strain). better naming scheme?
+// TACSOrder1Beam, TACSOrder2Beam, etc?
+typedef TACSBeamElement<TACSBeamLinearQuadrature, TACSBeamBasis<2>,
+                        TACSLinearizedRotation, TACSBeamLinearModel> TACSLinearBeam;
+
+typedef TACSBeamElement<TACSBeamQuadraticQuadrature, TACSBeamBasis<3>,
+                        TACSLinearizedRotation, TACSBeamLinearModel> TACSQuadBeam;
+
+typedef TACSBeamElement<TACSBeamLinearQuadrature, TACSBeamBasis<2>,
+                        TACSQuadraticRotation, TACSBeamLinearModel> TACSLinearBeamModRot;
+
+typedef TACSBeamElement<TACSBeamQuadraticQuadrature, TACSBeamBasis<3>,
+                        TACSQuadraticRotation, TACSBeamLinearModel> TACSQuadBeamModRot;
+
+typedef TACSBeamElement<TACSBeamLinearQuadrature, TACSBeamBasis<2>,
+                        TACSQuaternionRotation, TACSBeamLinearModel> TACSLinearBeamQuaternion;
+
+typedef TACSBeamElement<TACSBeamQuadraticQuadrature, TACSBeamBasis<3>,
+                        TACSQuaternionRotation, TACSBeamLinearModel> TACSQuadBeamQuaternion;
+
 /**
   Create a TACS shell element based on the name of the shell.
 

--- a/tacs/constitutive.pxd
+++ b/tacs/constitutive.pxd
@@ -114,12 +114,16 @@ cdef extern from "TACSLamParamShellConstitutive.h":
 
 cdef extern from "TACSBeamConstitutive.h":
     cdef cppclass TACSBeamConstitutive(TACSConstitutive):
-        TACSBeamConstitutive(TacsScalar, TacsScalar, TacsScalar, TacsScalar,
-                             TacsScalar, TacsScalar, TacsScalar, TacsScalar,
-                             TacsScalar, TacsScalar, const TacsScalar*)
+        TACSBeamConstitutive()
 
 cdef class BeamConstitutive(Constitutive):
     cdef TACSBeamConstitutive *cptr
+
+cdef extern from "TACSBasicBeamConstitutive.h":
+    cdef cppclass TACSBasicBeamConstitutive(TACSBeamConstitutive):
+        TACSBasicBeamConstitutive(TacsScalar, TacsScalar, TacsScalar, TacsScalar,
+                                  TacsScalar, TacsScalar, TacsScalar, TacsScalar,
+                                  TacsScalar, TacsScalar)
 
 cdef extern from "TACSGeneralMassConstitutive.h":
     cdef cppclass TACSGeneralMassConstitutive(TACSConstitutive):

--- a/tacs/constitutive.pxd
+++ b/tacs/constitutive.pxd
@@ -121,8 +121,7 @@ cdef class BeamConstitutive(Constitutive):
 
 cdef extern from "TACSBasicBeamConstitutive.h":
     cdef cppclass TACSBasicBeamConstitutive(TACSBeamConstitutive):
-        TACSBasicBeamConstitutive(TacsScalar, TacsScalar, TacsScalar, TacsScalar,
-                                  TacsScalar, TacsScalar, TacsScalar, TacsScalar,
+        TACSBasicBeamConstitutive(TACSMaterialProperties*, TacsScalar, TacsScalar, TacsScalar,
                                   TacsScalar, TacsScalar)
 
 cdef extern from "TACSIsoTubeBeamConstitutive.h":

--- a/tacs/constitutive.pxd
+++ b/tacs/constitutive.pxd
@@ -114,7 +114,7 @@ cdef extern from "TACSLamParamShellConstitutive.h":
 
 cdef extern from "TACSBeamConstitutive.h":
     cdef cppclass TACSBeamConstitutive(TACSConstitutive):
-        TACSBeamConstitutive()
+        pass
 
 cdef class BeamConstitutive(Constitutive):
     cdef TACSBeamConstitutive *cptr
@@ -124,6 +124,11 @@ cdef extern from "TACSBasicBeamConstitutive.h":
         TACSBasicBeamConstitutive(TacsScalar, TacsScalar, TacsScalar, TacsScalar,
                                   TacsScalar, TacsScalar, TacsScalar, TacsScalar,
                                   TacsScalar, TacsScalar)
+
+cdef extern from "TACSIsoTubeBeamConstitutive.h":
+    cdef cppclass TACSIsoTubeBeamConstitutive(TACSBeamConstitutive):
+        TACSIsoTubeBeamConstitutive(TACSMaterialProperties*, TacsScalar, TacsScalar,
+                                    int, int, TacsScalar, TacsScalar, TacsScalar, TacsScalar)
 
 cdef extern from "TACSGeneralMassConstitutive.h":
     cdef cppclass TACSGeneralMassConstitutive(TACSConstitutive):

--- a/tacs/constitutive.pyx
+++ b/tacs/constitutive.pyx
@@ -522,8 +522,8 @@ cdef class IsoShellConstitutive(ShellConstitutive):
         t (float or complex, optional): The material thickness (keyword argument). Defaults to 1.0.
         tNum (int, optional): Design variable number to assign to thickness (keyword argument). Defaults to -1
             (i.e. no design variable).
-        tlb (float or complex, optional): Thickness varaible lower bound (keyword argument). Defaults to 0.0.
-        tub (float or complex, optional): Thickness varaible upper bound (keyword argument). Defaults to 10.0.
+        tlb (float or complex, optional): Thickness variable lower bound (keyword argument). Defaults to 0.0.
+        tub (float or complex, optional): Thickness variable upper bound (keyword argument). Defaults to 10.0.
     """
     def __cinit__(self, *args, **kwargs):
         cdef TACSMaterialProperties *props = NULL
@@ -686,6 +686,62 @@ cdef class BasicBeamConstitutive1(BeamConstitutive):
                                                   EA, GJ, EIy, EIz, kGAy, kGAz)
         self.ptr = self.cptr
         self.ptr.incref()
+
+cdef class IsoTubeBeamConstitutive(BeamConstitutive):
+    """
+    Timoshenko theory based constitutive object for a hollow circular beam.
+
+    Args:
+        props (MaterialProperties): The material property.
+        d (float or complex, optional): Tube inner diameter (keyword argument). Defaults to 1.0.
+        dNum (int, optional): Design variable number to assign to tube diameter (keyword argument). Defaults to -1
+            (i.e. no design variable).
+        dlb (float or complex, optional): Lower bound on tube diameter (keyword argument). Defaults to 0.0.
+        dub (float or complex, optional): Upper bound on tube diameter (keyword argument). Defaults to 10.0.
+        t (float or complex, optional): Tube wall thickness (keyword argument). Defaults to 0.1.
+        tNum (int, optional): Design variable number to assign to wall thickness (keyword argument). Defaults to -1
+            (i.e. no design variable).
+        tlb (float or complex, optional): Lower bound on wall thickness (keyword argument). Defaults to 0.0.
+        tub (float or complex, optional): Upper bound on wall thickness (keyword argument). Defaults to 10.0.
+    """
+    def __cinit__(self, *args, **kwargs):
+        cdef TACSMaterialProperties *props = NULL
+        cdef TacsScalar d = 1.0
+        cdef int dNum = -1
+        cdef TacsScalar dlb = 0.0
+        cdef TacsScalar dub = 10.0
+        cdef TacsScalar t = 0.1
+        cdef int tNum = -1
+        cdef TacsScalar tlb = 0.0
+        cdef TacsScalar tub = 10.0
+
+        if len(args) >= 1:
+            props = (<MaterialProperties>args[0]).ptr
+        if 'd' in kwargs:
+            d = kwargs['d']
+        if 'dNum' in kwargs:
+            dNum = kwargs['dNum']
+        if 'dlb' in kwargs:
+            dlb = kwargs['dlb']
+        if 'dub' in kwargs:
+            dub = kwargs['dub']
+        if 't' in kwargs:
+            t = kwargs['t']
+        if 'tNum' in kwargs:
+            tNum = kwargs['tNum']
+        if 'tlb' in kwargs:
+            tlb = kwargs['tlb']
+        if 'tub' in kwargs:
+            tub = kwargs['tub']
+
+        if props is not NULL:
+            self.cptr = new TACSIsoTubeBeamConstitutive(props, d, t, dNum, tNum,
+                                                        dlb, dub, tlb, tub)
+            self.ptr = self.cptr
+            self.ptr.incref()
+        else:
+            self.ptr = NULL
+            self.cptr = NULL
 
 cdef class GeneralMassConstitutive(Constitutive):
     """

--- a/tacs/constitutive.pyx
+++ b/tacs/constitutive.pyx
@@ -664,13 +664,26 @@ cdef class LamParamShellConstitutive(ShellConstitutive):
         self.ptr = self.cptr
         self.ptr.incref()
 
-cdef class BeamConstitutive(Constitutive):
-    def __cinit__(self, rhoA, rhoIy, rhoIz, rhoIyz,
-                  EA, GJ, EIy, EIz, kGAy, kGAz,
-                  np.ndarray[TacsScalar, ndim=1, mode='c'] axis):
-        self.cptr = new TACSBeamConstitutive(rhoA, rhoIy, rhoIz, rhoIyz,
-                                             EA, GJ, EIy, EIz, kGAy, kGAz,
-                                             <TacsScalar*>axis.data)
+cdef class BasicBeamConstitutive1(BeamConstitutive):
+    """
+    Timoshenko theory based constitutive object for an uncoupled beam.
+
+    Args:
+        rhoA (float or complex): Mass per unit span
+        rhoJ (float or complex): Rotational mass of inertia about x-axis
+        rhoIy (float or complex): Rotational mass moment of inertia about y-axis
+        rhoIz (float or complex): Rotational mass moment of inertia about z-axis
+        EA (float or complex): Axial stiffness
+        GJ (float or complex): Torsional stiffness
+        EIy (float or complex): Bending stiffness in z-axis
+        EIz (float or complex): Bending stiffness in y-axis
+        kGAy (float or complex): Shearing stiffness in y-axis
+        kGAz (float or complex): Shearing stiffness in z-axis
+    """
+    def __cinit__(self, rhoA, rhoJ, rhoIy, rhoIz,
+                  EA, GJ, EIy, EIz, kGAy, kGAz):
+        self.cptr = new TACSBasicBeamConstitutive(rhoA, rhoJ, rhoIy, rhoIz,
+                                                  EA, GJ, EIy, EIz, kGAy, kGAz)
         self.ptr = self.cptr
         self.ptr.incref()
 

--- a/tacs/constitutive.pyx
+++ b/tacs/constitutive.pyx
@@ -669,21 +669,35 @@ cdef class BasicBeamConstitutive1(BeamConstitutive):
     Timoshenko theory based constitutive object for an uncoupled beam.
 
     Args:
-        rhoA (float or complex): Mass per unit span
-        rhoJ (float or complex): Rotational mass of inertia about x-axis
-        rhoIy (float or complex): Rotational mass moment of inertia about y-axis
-        rhoIz (float or complex): Rotational mass moment of inertia about z-axis
-        EA (float or complex): Axial stiffness
-        GJ (float or complex): Torsional stiffness
-        EIy (float or complex): Bending stiffness in z-axis
-        EIz (float or complex): Bending stiffness in y-axis
-        kGAy (float or complex): Shearing stiffness in y-axis
-        kGAz (float or complex): Shearing stiffness in z-axis
+        props (MaterialProperties): The material property.
+        A (float or complex): Beam cross-sectional area (keyword argument). Defaults to 0.0.
+        J (float or complex): Beam polar moment of inertia about x-axis (keyword argument). Defaults to 0.0.
+        Iy (float or complex): Beam area moment of inertia about y-axis (keyword argument). Defaults to 0.0.
+        Iz (float or complex): Beam area moment of inertia about z-axis (keyword argument). Defaults to 0.0.
+        kcorr (float or complex): Shear correction factor (keyword argument). Defaults to 5/6.
     """
-    def __cinit__(self, rhoA, rhoJ, rhoIy, rhoIz,
-                  EA, GJ, EIy, EIz, kGAy, kGAz):
-        self.cptr = new TACSBasicBeamConstitutive(rhoA, rhoJ, rhoIy, rhoIz,
-                                                  EA, GJ, EIy, EIz, kGAy, kGAz)
+    def __cinit__(self, *args, **kwargs):
+        cdef TACSMaterialProperties *props = NULL
+        cdef TacsScalar A = 0.0
+        cdef TacsScalar J = 0.0
+        cdef TacsScalar Iy = 0.0
+        cdef TacsScalar Iz = 0.0
+        cdef TacsScalar kcorr = 5.0/6.0
+
+        if len(args) >= 1:
+            props = (<MaterialProperties>args[0]).ptr
+        if 'A' in kwargs:
+            A = kwargs['A']
+        if 'J' in kwargs:
+            J = kwargs['J']
+        if 'Iy' in kwargs:
+            Iy = kwargs['Iy']
+        if 'Iz' in kwargs:
+            Iz = kwargs['Iz']
+        if 'kcorr' in kwargs:
+            kcorr = kwargs['kcorr']
+
+        self.cptr = new TACSBasicBeamConstitutive(props, A, J, Iy, Iz, kcorr)
         self.ptr = self.cptr
         self.ptr.incref()
 

--- a/tacs/elements.pxd
+++ b/tacs/elements.pxd
@@ -188,7 +188,14 @@ cdef extern from "TACSShellElementTransform.h":
         TACSShellNaturalTransform()
 
     cdef cppclass TACSShellRefAxisTransform(TACSShellTransform):
-        TACSShellRefAxisTransform(TacsScalar*)
+        TACSShellRefAxisTransform(const TacsScalar*)
+
+cdef extern from "TACSBeamElement.h":
+    cdef cppclass TACSBeamTransform(TACSObject):
+        pass
+
+    cdef cppclass TACSBeamRefAxisTransform(TACSBeamTransform):
+        TACSBeamRefAxisTransform(const TacsScalar*)
 
 cdef extern from "TACSShellElementDefs.h":
     cdef cppclass TACSQuad4Shell(TACSElement):
@@ -222,6 +229,30 @@ cdef extern from "TACSShellElementDefs.h":
     cdef cppclass TACSTri3ThermalShell(TACSElement):
         TACSTri3ThermalShell(TACSShellTransform*,
                              TACSShellConstitutive*)
+
+    cdef cppclass TACSLinearBeam(TACSElement):
+        TACSLinearBeam(TACSBeamTransform*,
+                       TACSBeamConstitutive*)
+
+    cdef cppclass TACSQuadBeam(TACSElement):
+        TACSQuadBeam(TACSBeamTransform*,
+                     TACSBeamConstitutive*)
+
+    cdef cppclass TACSLinearBeamModRot(TACSElement):
+        TACSLinearBeamModRot(TACSBeamTransform*,
+                             TACSBeamConstitutive*)
+
+    cdef cppclass TACSQuadBeamModRot(TACSElement):
+        TACSQuadBeamModRot(TACSBeamTransform*,
+                           TACSBeamConstitutive*)
+
+    cdef cppclass TACSLinearBeamQuaternion(TACSElement):
+        TACSLinearBeamQuaternion(TACSBeamTransform*,
+                                 TACSBeamConstitutive*)
+
+    cdef cppclass TACSQuadBeamQuaternion(TACSElement):
+        TACSQuadBeamQuaternion(TACSBeamTransform*,
+                               TACSBeamConstitutive*)
 
 cdef extern from "TACSSpringElementTransform.h":
     cdef cppclass TACSSpringTransform(TACSObject):

--- a/tacs/elements.pyx
+++ b/tacs/elements.pyx
@@ -797,6 +797,53 @@ cdef class Tri3ThermalShell(Element):
         self.ptr = new TACSTri3ThermalShell(transform.ptr, con.cptr)
         self.ptr.incref()
 
+cdef class BeamTransform:
+    cdef TACSBeamTransform *ptr
+    def __cinit__(self):
+        self.ptr = NULL
+        return
+
+    def __dealloc__(self):
+        if self.ptr != NULL:
+            self.ptr.decref()
+
+cdef class BeamRefAxisTransform(BeamTransform):
+    """
+    Class for computing the transformation from the global coordinates
+    to the beam local coordinates (used for defining stresses).
+    This class uses a projection of a user-supplied reference axis to define the beam coordinate system
+    (i.e. local :math:`y` is aligned with the reference axis.)
+
+    .. warning:: The reference direction cannot be parallel to the beam axis.
+
+    Args:
+        axis (array-like): Reference axis.
+    """
+    def __cinit__(self, axis):
+        cdef TacsScalar a[3]
+        a[0] = axis[0]
+        a[1] = axis[1]
+        a[2] = axis[2]
+        self.ptr = new TACSBeamRefAxisTransform(a)
+        self.ptr.incref()
+
+cdef class LinearBeam(Element):
+    """
+    A 2-node Timoshenko beam element for general linear elastic analysis.
+
+    .. note::
+        varsPerNode: 6
+
+        outputElement: ``TACS.BEAM_OR_SHELL_ELEMENT``
+
+    Args:
+        transform (BeamTransform): Beam transform object.
+        con (BeamConstitutive): Beam constitutive object.
+    """
+    def __cinit__(self, BeamTransform transform, BeamConstitutive con):
+        self.ptr = new TACSLinearBeam(transform.ptr, con.cptr)
+        self.ptr.incref()
+
 cdef class SpringTransform:
     cdef TACSSpringTransform *ptr
     def __cinit__(self):

--- a/tests/constitutive_tests/test_basic_beam_constitutive.py
+++ b/tests/constitutive_tests/test_basic_beam_constitutive.py
@@ -1,0 +1,94 @@
+from tacs import TACS, constitutive, elements
+import numpy as np
+import unittest
+
+class ConstitutiveTest(unittest.TestCase):
+    def setUp(self):
+        # fd/cs step size
+        if TACS.dtype is complex:
+            self.dh = 1e-50
+            self.rtol = 1e-11
+        else:
+            self.dh = 1e-6
+            self.rtol = 1e-2
+        self.dtype = TACS.dtype
+
+        # Basically, only check relative tolerance
+        self.atol = 1e99
+        self.print_level = 0
+
+        # Set element index
+        self.elem_index = 0
+
+        # Set the variable arrays
+        self.x = np.ones(3, dtype=self.dtype)
+        self.pt = np.zeros(3)
+        # This constituitive class has no dvs
+        self.dvs = np.array([], dtype=self.dtype)
+
+        # General 6 dof stiffness matrix
+        """
+        K[ 0] K[ 1] K[ 2] K[ 3] K[ 4] K[ 5]
+        K[ 1] K[ 6] K[ 7] K[ 8] K[ 9] K[10]
+        K[ 2] K[ 7] K[11] K[12] K[13] K[14]
+        K[ 3] K[ 8] K[12] K[15] K[16] K[17]
+        K[ 4] K[ 9] K[13] K[16] K[18] K[19]
+        K[ 5] K[10] K[14] K[17] K[19] K[20]
+        """
+        rho = 2700.0
+        E = 70e9
+        G = 30e9
+        k = 5.0/6.0
+
+        A = 0.01
+        Iy = Iz = 1e-3
+        J = (Iy**2 + Iz**2)**0.5
+
+        # Create stiffness (need class)
+        self.con = constitutive.BasicBeamConstitutive1(rho*A, rho*J, rho*Iy, rho*Iz,
+                                                       E*A, G*J, E*Iy, E*Iz, k*G*A, k*G*A)
+
+        # Seed random number generator in tacs for consistent test results
+        elements.SeedRandomGenerator(0)
+
+    def test_constitutive_density(self):
+        # Test density dv sensitivity
+        fail = constitutive.TestConstitutiveDensity(self.con, self.elem_index, self.pt, self.x,
+                                                    self.dvs, self.dh, self.print_level, self.atol, self.rtol)
+        self.assertFalse(fail)
+
+    def test_constitutive_specific_heat(self):
+        # Test specific heat dv sensitivity
+        fail = constitutive.TestConstitutiveSpecificHeat(self.con, self.elem_index, self.pt, self.x,
+                                                         self.dvs, self.dh, self.print_level, self.atol, self.rtol)
+        self.assertFalse(fail)
+
+    def test_constitutive_heat_flux(self):
+        # Test heat flux dv sensitivity
+        fail = constitutive.TestConstitutiveHeatFlux(self.con, self.elem_index, self.pt, self.x,
+                                                     self.dvs, self.dh, self.print_level, self.atol, self.rtol)
+        self.assertFalse(fail)
+
+    def test_constitutive_stress(self):
+        # Test stress dv sensitivity
+        fail = constitutive.TestConstitutiveStress(self.con, self.elem_index, self.pt, self.x,
+                                                   self.dvs, self.dh, self.print_level, self.atol, self.rtol)
+        self.assertFalse(fail)
+
+    def test_constitutive_thermal_strain(self):
+        # Test thermal strain dv sensitivity
+        fail = constitutive.TestConstitutiveThermalStrain(self.con, self.elem_index, self.pt, self.x,
+                                                          self.dvs, self.dh, self.print_level, self.atol, self.rtol)
+        self.assertFalse(fail)
+
+    def test_constitutive_failure(self):
+        # Test failure dv sensitivity
+        fail = constitutive.TestConstitutiveFailure(self.con, self.elem_index, self.pt, self.x,
+                                                    self.dvs, self.dh, self.print_level, self.atol, self.rtol)
+        self.assertFalse(fail)
+
+    def test_constitutive_failure_strain_sens(self):
+        # Test failure dv sensitivity
+        fail = constitutive.TestConstitutiveFailureStrainSens(self.con, self.elem_index, self.pt, self.x,
+                                                              self.dh, self.print_level, self.atol, self.rtol)
+        self.assertFalse(fail)

--- a/tests/constitutive_tests/test_basic_beam_constitutive.py
+++ b/tests/constitutive_tests/test_basic_beam_constitutive.py
@@ -26,18 +26,25 @@ class ConstitutiveTest(unittest.TestCase):
         # This constituitive class has no dvs
         self.dvs = np.array([], dtype=self.dtype)
 
+        # Create the isotropic material
         rho = 2700.0
-        E = 70e9
-        G = 30e9
-        k = 5.0/6.0
+        specific_heat = 921.096
+        E = 70e3
+        nu = 0.3
+        ys = 270.0
+        cte = 24.0e-6
+        kappa = 230.0
+        self.props = constitutive.MaterialProperties(rho=rho, specific_heat=specific_heat,
+                                                     E=E, nu=nu, ys=ys, cte=cte, kappa=kappa)
 
         A = 0.01
         Iy = Iz = 1e-3
         J = (Iy**2 + Iz**2)**0.5
+        kcorr = 5.0/6.0
 
         # Create stiffness (need class)
-        self.con = constitutive.BasicBeamConstitutive1(rho*A, rho*J, rho*Iy, rho*Iz,
-                                                       E*A, G*J, E*Iy, E*Iz, k*G*A, k*G*A)
+        self.con = constitutive.BasicBeamConstitutive1(self.props, A=A, J=J, Iy=Iy, Iz=Iz,
+                                                       kcorr=kcorr)
 
         # Seed random number generator in tacs for consistent test results
         elements.SeedRandomGenerator(0)

--- a/tests/constitutive_tests/test_iso_tube_beam_constitutive.py
+++ b/tests/constitutive_tests/test_iso_tube_beam_constitutive.py
@@ -23,21 +23,25 @@ class ConstitutiveTest(unittest.TestCase):
         # Set the variable arrays
         self.x = np.ones(3, dtype=self.dtype)
         self.pt = np.zeros(3)
-        # This constituitive class has no dvs
-        self.dvs = np.array([], dtype=self.dtype)
+        self.dvs = np.array([1.0, 0.1], dtype=self.dtype)
 
+        # Create the isotropic material
         rho = 2700.0
-        E = 70e9
-        G = 30e9
-        k = 5.0/6.0
-
-        A = 0.01
-        Iy = Iz = 1e-3
-        J = (Iy**2 + Iz**2)**0.5
+        specific_heat = 921.096
+        E = 70e3
+        nu = 0.3
+        ys = 270.0
+        cte = 24.0e-6
+        kappa = 230.0
+        self.props = constitutive.MaterialProperties(rho=rho, specific_heat=specific_heat,
+                                                     E=E, nu=nu, ys=ys, cte=cte, kappa=kappa)
+        t = 0.1
+        d = 1.0
+        dNum = 0
+        tNum = 1
 
         # Create stiffness (need class)
-        self.con = constitutive.BasicBeamConstitutive1(rho*A, rho*J, rho*Iy, rho*Iz,
-                                                       E*A, G*J, E*Iy, E*Iz, k*G*A, k*G*A)
+        self.con = constitutive.IsoTubeBeamConstitutive(self.props, t=t, tNum=tNum, d=d, dNum=dNum)
 
         # Seed random number generator in tacs for consistent test results
         elements.SeedRandomGenerator(0)

--- a/tests/element_tests/shell_tests/test_beam_element.py
+++ b/tests/element_tests/shell_tests/test_beam_element.py
@@ -1,0 +1,147 @@
+from tacs import TACS, constitutive, elements
+import numpy as np
+import unittest
+
+class ElementTest(unittest.TestCase):
+    def setUp(self):
+        max_nodes = 64
+        max_vars_per_nodes = 8
+        max_vars = max_nodes * max_vars_per_nodes
+
+        # fd/cs step size
+        if TACS.dtype is complex:
+            self.dh = 1e-50
+            self.rtol = 1e-10
+        else:
+            self.dh = 1e-5
+            self.rtol = 1e-2
+        self.dtype = TACS.dtype
+
+        # Basically, only check relative tolerance
+        self.atol = 1e99
+        self.print_level = 0
+
+        # Set element index
+        self.elem_index = 0
+
+        # Set the simulation time
+        self.time = 0.0
+
+        # Set the variable arrays
+        np.random.seed(30)  # Seed random numbers for deterministic/repeatable tests
+        self.xpts = np.random.rand(3 * max_nodes).astype(self.dtype)
+        np.random.seed(30)  # Seed random numbers for deterministic/repeatable tests
+        self.vars = np.random.rand(max_vars).astype(self.dtype)
+        self.dvars = self.vars.copy()
+        self.ddvars = self.vars.copy()
+
+        # Create the isotropic material
+        rho = 2700.0
+        specific_heat = 921.096
+        E = 70e3
+        nu = 0.3
+        ys = 270.0
+        cte = 24.0e-6
+        kappa = 230.0
+        self.props = constitutive.MaterialProperties(rho=rho, specific_heat=specific_heat,
+                                                     E=E, nu=nu, ys=ys, cte=cte, kappa=kappa)
+
+        ref_axis = np.array([0.0, 1.0, 1.0], dtype=self.dtype)
+        self.transforms = [elements.BeamRefAxisTransform(ref_axis)]
+
+        # TACS shell elements of various orders and types
+        self.elements = [elements.LinearBeam]
+
+        t = 0.1
+        d = 1.0
+        dNum = 0
+        tNum = 1
+
+        # Create stiffness (need class)
+        self.con = constitutive.IsoTubeBeamConstitutive(self.props, t=t, tNum=tNum, d=d, dNum=dNum)
+
+        # Set matrix types
+        self.matrix_types = [TACS.STIFFNESS_MATRIX, TACS.MASS_MATRIX, TACS.GEOMETRIC_STIFFNESS_MATRIX]
+
+        # Seed random number generator in tacs for consistent test results
+        elements.SeedRandomGenerator(0)
+
+    def test_element_residual(self):
+        # Here we have to overwrite the step size rtol,
+        # because TestElementResidual only supports FD testing right now
+        dh = 1e-5
+        rtol = 1e-2
+        # Loop through every combination of transform type and shell element class and test residual
+        for transform in self.transforms:
+            with self.subTest(transform=transform):
+                for element_handle in self.elements:
+                    with self.subTest(element=element_handle):
+                        element = element_handle(transform, self.con)
+                        fail = elements.TestElementResidual(element, self.elem_index, self.time, self.xpts,
+                                                            self.vars, self.dvars, self.ddvars, dh,
+                                                            self.print_level, self.atol, rtol)
+                        self.assertFalse(fail)
+
+    def test_element_jacobian(self):
+        # Loop through every combination of transform type and shell element class and test Jacobian
+        for transform in self.transforms:
+            with self.subTest(transform=transform):
+                for element_handle in self.elements:
+                    with self.subTest(element=element_handle):
+                        element = element_handle(transform, self.con)
+                        fail = elements.TestElementJacobian(element, self.elem_index, self.time, self.xpts,
+                                                            self.vars, self.dvars, self.ddvars, -1, self.dh,
+                                                            self.print_level, self.atol, self.rtol)
+                        self.assertFalse(fail)
+
+    def test_adj_res_product(self):
+        # Loop through every combination of transform type and shell element class and test adjoint residual-dvsens product
+        for transform in self.transforms:
+            with self.subTest(transform=transform):
+                for element_handle in self.elements:
+                    with self.subTest(element=element_handle):
+                        element = element_handle(transform, self.con)
+                        dvs = element.getDesignVars(self.elem_index)
+                        fail = elements.TestAdjResProduct(element, self.elem_index, self.time, self.xpts,
+                                                          self.vars, self.dvars, self.ddvars, dvs, self.dh,
+                                                          self.print_level, self.atol, self.rtol)
+                        self.assertFalse(fail)
+
+    def test_adj_res_xpt_product(self):
+        # Loop through every combination of transform type and shell element class and test adjoint residual-xptsens product
+        for transform in self.transforms:
+            with self.subTest(transform=transform):
+                for element_handle in self.elements:
+                    with self.subTest(element=element_handle):
+                        element = element_handle(transform, self.con)
+                        fail = elements.TestAdjResXptProduct(element, self.elem_index, self.time, self.xpts,
+                                                             self.vars, self.dvars, self.ddvars, self.dh,
+                                                             self.print_level, self.atol, self.rtol)
+                        self.assertFalse(fail)
+
+    def test_element_mat_dv_sens(self):
+        # Loop through every combination of transform type and shell element class and element matrix inner product sens
+        for transform in self.transforms:
+            with self.subTest(transform=transform):
+                for element_handle in self.elements:
+                    with self.subTest(element=element_handle):
+                        element = element_handle(transform, self.con)
+                        dvs = element.getDesignVars(self.elem_index)
+                        for matrix_type in self.matrix_types:
+                            with self.subTest(matrix_type=matrix_type):
+                                fail = elements.TestElementMatDVSens(element, matrix_type, self.elem_index,
+                                                                     self.time, self.xpts, self.vars, dvs, self.dh,
+                                                                     self.print_level, self.atol, self.rtol)
+                                self.assertFalse(fail)
+
+    def test_element_mat_sv_sens(self):
+        # Loop through every combination of model and basis class and test element matrix inner product sens
+        for transform in self.transforms:
+            with self.subTest(transform=transform):
+                for element_handle in self.elements:
+                    with self.subTest(element=element_handle):
+                        element = element_handle(transform, self.con)
+                        fail = elements.TestElementMatSVSens(element, TACS.GEOMETRIC_STIFFNESS_MATRIX, self.elem_index,
+                                                             self.time, self.xpts, self.vars, self.dh,
+                                                             self.print_level, self.atol, self.rtol)
+                        self.assertFalse(fail)

--- a/tests/element_tests/shell_tests/test_beam_element.py
+++ b/tests/element_tests/shell_tests/test_beam_element.py
@@ -49,7 +49,7 @@ class ElementTest(unittest.TestCase):
         ref_axis = np.array([0.0, 1.0, 1.0], dtype=self.dtype)
         self.transforms = [elements.BeamRefAxisTransform(ref_axis)]
 
-        # TACS shell elements of various orders and types
+        # TACS beam elements of various orders and types
         self.elements = [elements.LinearBeam]
 
         t = 0.1
@@ -71,7 +71,7 @@ class ElementTest(unittest.TestCase):
         # because TestElementResidual only supports FD testing right now
         dh = 1e-5
         rtol = 1e-2
-        # Loop through every combination of transform type and shell element class and test residual
+        # Loop through every combination of transform type and beam element class and test residual
         for transform in self.transforms:
             with self.subTest(transform=transform):
                 for element_handle in self.elements:
@@ -83,7 +83,7 @@ class ElementTest(unittest.TestCase):
                         self.assertFalse(fail)
 
     def test_element_jacobian(self):
-        # Loop through every combination of transform type and shell element class and test Jacobian
+        # Loop through every combination of transform type and beam element class and test Jacobian
         for transform in self.transforms:
             with self.subTest(transform=transform):
                 for element_handle in self.elements:
@@ -95,7 +95,7 @@ class ElementTest(unittest.TestCase):
                         self.assertFalse(fail)
 
     def test_adj_res_product(self):
-        # Loop through every combination of transform type and shell element class and test adjoint residual-dvsens product
+        # Loop through every combination of transform type and beam element class and test adjoint residual-dvsens product
         for transform in self.transforms:
             with self.subTest(transform=transform):
                 for element_handle in self.elements:
@@ -108,7 +108,7 @@ class ElementTest(unittest.TestCase):
                         self.assertFalse(fail)
 
     def test_adj_res_xpt_product(self):
-        # Loop through every combination of transform type and shell element class and test adjoint residual-xptsens product
+        # Loop through every combination of transform type and beam element class and test adjoint residual-xptsens product
         for transform in self.transforms:
             with self.subTest(transform=transform):
                 for element_handle in self.elements:
@@ -120,7 +120,7 @@ class ElementTest(unittest.TestCase):
                         self.assertFalse(fail)
 
     def test_element_mat_dv_sens(self):
-        # Loop through every combination of transform type and shell element class and element matrix inner product sens
+        # Loop through every combination of transform type and beam element class and element matrix inner product sens
         for transform in self.transforms:
             with self.subTest(transform=transform):
                 for element_handle in self.elements:


### PR DESCRIPTION
- Adding beam classes to cython wrapper
- Adding tests for beam classes
- Adding python example for 5 element beam problem
- Beam example doesn't seem to work due to singular matrix